### PR TITLE
Reinstating iterator to since variable

### DIFF
--- a/ccxtbt/ccxtfeed.py
+++ b/ccxtbt/ccxtfeed.py
@@ -195,6 +195,7 @@ class CCXTFeed(with_metaclass(MetaCCXTFeed, DataBase)):
                         print('Adding: {}'.format(ohlcv))
                     self._data.append(ohlcv)
                     self._last_ts = tstamp
+                    since = tstamp + 1
 
             if dlen == len(self._data):
                 break


### PR DESCRIPTION
The line allows the data collection to move forward, otherwise it causes an infinite loop after the first cycle of collection.